### PR TITLE
 Update deps to track latest rethinkdb and ecto.

### DIFF
--- a/lib/rethinkdb_ecto/connection.ex
+++ b/lib/rethinkdb_ecto/connection.ex
@@ -50,7 +50,7 @@ defmodule RethinkDB.Ecto.Connection do
 
   defp do_insert(connection, changeset) do
     model = Ecto.Changeset.apply_changes(changeset)
-    module = model.__struct__ 
+    module = model.__struct__
     Ecto.Model.Callbacks.__apply__(module, :before_insert, changeset)
     table = model_table(model)
     data = model
@@ -87,7 +87,7 @@ defmodule RethinkDB.Ecto.Connection do
 
   defp do_update(connection, changeset) do
     model = Ecto.Changeset.apply_changes(changeset)
-    module = model.__struct__ 
+    module = model.__struct__
     id = model.id
     Ecto.Model.Callbacks.__apply__(module, :before_update, changeset)
     table = model_table(model)

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule RethinkdbEcto.Mixfile do
   #
   # Type "mix help deps" for more examples and options
   defp deps do
-    [{:ecto, "~> 2.0.0-beta.2"},
+    [{:ecto, "~> 1.1.5"},
      {:rethinkdb, "~> 0.4.0"}]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -27,6 +27,7 @@ defmodule RethinkdbEcto.Mixfile do
   #
   # Type "mix help deps" for more examples and options
   defp deps do
-    [{:rethinkdb, "~> 0.3.0"}]
+    [{:ecto, "~> 2.0.0-beta.2"},
+     {:rethinkdb, "~> 0.4.0"}]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,6 @@
-%{"connection": {:hex, :connection, "1.0.1"},
-  "poison": {:hex, :poison, "1.5.0"},
-  "rethinkdb": {:hex, :rethinkdb, "0.2.0"}}
+%{"connection": {:hex, :connection, "1.0.2"},
+  "decimal": {:hex, :decimal, "1.1.1"},
+  "ecto": {:hex, :ecto, "2.0.0-beta.2"},
+  "poison": {:hex, :poison, "2.1.0"},
+  "poolboy": {:hex, :poolboy, "1.5.1"},
+  "rethinkdb": {:hex, :rethinkdb, "0.4.0"}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{"connection": {:hex, :connection, "1.0.2"},
   "decimal": {:hex, :decimal, "1.1.1"},
-  "ecto": {:hex, :ecto, "2.0.0-beta.2"},
-  "poison": {:hex, :poison, "2.1.0"},
+  "ecto": {:hex, :ecto, "1.1.5"},
+  "poison": {:hex, :poison, "1.5.2"},
   "poolboy": {:hex, :poolboy, "1.5.1"},
   "rethinkdb": {:hex, :rethinkdb, "0.4.0"}}


### PR DESCRIPTION
As is, rethinkdb_ecto fails to compile since it lacks an ecto dependency, and causes dependency resolution errors because it tracks an older version of the rethinkdb library. This PR updates deps to track the latest stable versions of both.
